### PR TITLE
Lock 'openmrs' tool to version 3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,6 @@ if [ $# -eq 0 ]; then
 fi
 
 mvn clean compile
-rm -r ~/openmrs/$1/frontend
+rm -r ~/openmrs/$1/frontend || echo No ~/openmrs/$1/frontend directory found
 cp -r target/dist ~/openmrs/$1/frontend
 ln -s ~/openmrs/$1/configuration/frontend ~/openmrs/$1/frontend/site

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
                             <goal>npx</goal>
                         </goals>
                         <configuration>
-                            <arguments>openmrs@next build --build-config spa-build-config.json --target target/dist</arguments>
+                            <arguments>openmrs@3.x build --build-config spa-build-config.json --target target/dist</arguments>
                         </configuration>
                     </execution>
                     <execution>
@@ -102,7 +102,7 @@
                             <goal>npx</goal>
                         </goals>
                         <configuration>
-                            <arguments>openmrs@next assemble --mode config --config spa-build-config.json --target target/dist</arguments>
+                            <arguments>openmrs@3.x assemble --mode config --config spa-build-config.json --target target/dist</arguments>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This will ensure that the tooling doesn't end up using version 4 when that gets released, before we have a chance to update our MFEs.